### PR TITLE
feat(hooks): Obsidianノート名にbranchとClaude要約slugを使う

### DIFF
--- a/.claude/hooks/log-to-obsidian.sh
+++ b/.claude/hooks/log-to-obsidian.sh
@@ -11,6 +11,8 @@
 # 冪等性は $HOME/.claude/claude-obsidian-log/<key>.count に
 # 「これまでに読み込んだトランスクリプト行数」を保存することで担保する
 # （このリポジトリの管理対象外＝git管理されないマシンローカル状態）。
+# 同ディレクトリの <key>.slug には Claude によるノート名要約のキャッシュ
+# (obsidian-note-lib.sh の session_note_basename) も置かれる。
 #
 # 書き込みは obsidian CLI ではなく vault への直接ファイル書き込みで行う。
 # obsidian CLI は GUI バイナリそのもので、呼び出しごとにフル Electron
@@ -37,13 +39,13 @@ agent_type="$(jq -r '.agent_type // empty' <<<"$input")"
 is_subagent=false
 [[ "$hook_event_name" == "SubagentStop" && -n "$agent_id" ]] && is_subagent=true
 
-state_dir="$HOME/.claude/claude-obsidian-log"
-mkdir -p "$state_dir"
+state_dir="$(obsidian_state_dir)"
 if [[ "$is_subagent" == "true" ]]; then
-  state_file="$state_dir/${session_id}_${agent_id}.count"
+  cache_key="${session_id}_${agent_id}"
 else
-  state_file="$state_dir/${session_id}.count"
+  cache_key="$session_id"
 fi
+state_file="$state_dir/${cache_key}.count"
 
 # Stop フック起動時点では、直前のツール呼び出し後に続く
 # アシスタントの最終テキストがまだ transcript ファイルに
@@ -121,8 +123,7 @@ project="$(resolve_project "$transcript_path" "$cwd")"
 started_at="$(jq -rn 'first(inputs | .timestamp // empty)' "$transcript_path")"
 timestamp="$(note_stamp "$started_at")"
 [[ -z "$timestamp" ]] && timestamp="$(date +%Y-%m-%dT%H-%M-%S)"
-slug="$(note_slug "$transcript_path" "$is_subagent")"
-[[ -z "$slug" ]] && slug="無題"
+basename_stem="$(session_note_basename "$transcript_path" "$is_subagent" "$cache_key" "$state_dir" "$timestamp")"
 
 # サブエージェントのノートは SubAgent/ 配下に分け、プロジェクトフォルダ
 # 直下がメインセッションのノートだけになるようにする (横並びだと見づらい)。
@@ -130,9 +131,9 @@ slug="$(note_slug "$transcript_path" "$is_subagent")"
 conv_dir="ClaudeCode/${project}/Conversations/$(note_yyyymm "$timestamp")"
 if [[ "$is_subagent" == "true" ]]; then
   agent_short="${agent_id:0:8}"
-  note_path="${conv_dir}/SubAgent/${timestamp}_${slug}_${agent_short}.md"
+  note_path="${conv_dir}/SubAgent/${basename_stem}_${agent_short}.md"
 else
-  note_path="${conv_dir}/${timestamp}_${slug}.md"
+  note_path="${conv_dir}/${basename_stem}.md"
 fi
 
 # サブエージェントのノート冒頭には親セッションのノートへの wikilink を入れ、
@@ -148,12 +149,12 @@ if [[ "$is_subagent" == "true" ]]; then
   parent_transcript="${transcript_path%/subagents/*}.jsonl"
   if [[ "$parent_transcript" != "$transcript_path" && -f "$parent_transcript" ]]; then
     parent_stamp="$(note_stamp "$(jq -rn 'first(inputs | .timestamp // empty)' "$parent_transcript")")"
-    parent_slug="$(note_slug "$parent_transcript" false)"
-    if [[ -n "$parent_stamp" && -n "$parent_slug" ]]; then
+    if [[ -n "$parent_stamp" ]]; then
+      parent_basename="$(session_note_basename "$parent_transcript" false "$session_id" "$state_dir" "$parent_stamp")"
       # タスクノート (Tasks/ 配下) がセッションノートと同名なため、
       # basename ではなくフルパスで修飾して曖昧さを避ける。
-      parent_note="ClaudeCode/${project}/Conversations/$(note_yyyymm "$parent_stamp")/${parent_stamp}_${parent_slug}"
-      parent_link="親セッション: [[${parent_note}|${parent_stamp}_${parent_slug}]]"
+      parent_note="ClaudeCode/${project}/Conversations/$(note_yyyymm "$parent_stamp")/${parent_basename}"
+      parent_link="親セッション: [[${parent_note}|${parent_basename}]]"
     fi
   fi
 fi

--- a/.claude/hooks/obsidian-note-lib.sh
+++ b/.claude/hooks/obsidian-note-lib.sh
@@ -11,10 +11,9 @@ note_stamp() {
   printf '%s' "${ts//:/-}"
 }
 
-# ノートファイル名は最初のユーザー発言(サブエージェントならタスク文)の
-# 先頭を要約として使う。Session ID っぽい無意味な suffix を避けるため。
-# note_slug <transcript_path> <is_subagent:true|false>
-note_slug() {
+# 最初のユーザー発言(サブエージェントならタスク文)の全文を返す。
+# first_user_message <transcript_path> <is_subagent:true|false>
+first_user_message() {
   jq -rn --argjson is_subagent "$2" '
     first(
       inputs
@@ -26,12 +25,89 @@ note_slug() {
         else ([.[] | select(.type == "text") | .text] | join(" "))
         end
       | gsub("\\s+"; " ")
-      | gsub("/"; "_")
       | sub("^ +"; "") | sub(" +$"; "")
       | select(length > 0)
-      | if length > 30 then .[0:30] + "…" else . end
     )
   ' "$1"
+}
+
+# Claude による要約が使えない/失敗した場合のフォールバック slug。
+# 先頭30文字にそのまま切り詰めるだけの単純な要約。
+# fallback_slug <text>
+fallback_slug() {
+  local text="${1//\//_}"
+  if (( ${#text} > 30 )); then
+    printf '%s…' "${text:0:30}"
+  else
+    printf '%s' "$text"
+  fi
+}
+
+# 最初のユーザー発言を Claude (haiku, hooks 無効・非永続) で25文字以内の
+# 見出しに要約する。この呼び出し自体が Stop フックを再発火して自分自身を
+# ログしてしまわないよう --safe-mode (hooks/CLAUDE.md/MCP 等を無効化、
+# 認証は通常の OAuth のまま) と --no-session-persistence (transcript を
+# 一切書き出さない) を必ず付ける。失敗・空応答時は fallback_slug を使う。
+# summarize_slug <transcript_path> <is_subagent:true|false>
+summarize_slug() {
+  local text summarized
+  text="$(first_user_message "$1" "$2")"
+  [[ -z "$text" ]] && { printf '無題'; return; }
+
+  # claude -p が非ゼロ終了 (ネットワーク不調・予算超過等) しても
+  # set -e で呼び出し元スクリプトごと落ちないよう `|| true` で握り潰す。
+  summarized="$(claude -p --safe-mode --no-session-persistence \
+    --model haiku --output-format text --max-budget-usd 0.02 \
+    "次のユーザーの発言を25文字以内の日本語の見出しに要約して。見出しのみを1行で出力し、記号・句読点・前置きは付けないこと:
+
+${text}" 2>/dev/null | tr -d '\n')" || true
+  summarized="${summarized//\//_}"
+
+  if [[ -n "$summarized" ]]; then
+    printf '%s' "$summarized"
+  else
+    printf '%s' "$(fallback_slug "$text")"
+  fi
+}
+
+# 作業ブランチの短縮名。パスの最後のセグメントだけを使い、長すぎる
+# ブランチ名でファイル名が肥大化しないよう上限を設ける。
+# ブランチが取れない(非 git dir / detached 等)場合は空文字を返す。
+# note_branch <transcript_path>
+note_branch() {
+  local branch
+  branch="$(jq -rn 'first(inputs | .gitBranch // empty)' "$1")"
+  [[ -z "$branch" ]] && return
+  branch="${branch##*/}"
+  if (( ${#branch} > 24 )); then
+    branch="${branch:0:24}"
+  fi
+  printf '%s' "$branch"
+}
+
+# セッション/サブエージェントノートの basename ("{stamp}_{branch}_{slug}",
+# ブランチが取れない場合は "{stamp}_{slug}") を解決する。
+# slug の要約は state_dir に cache_key ごとキャッシュし、同一セッション内で
+# 何度呼ばれても Claude 呼び出しが1回で済むようにする（タスクノートと
+# 会話ログノートの両方から呼ばれるため、basename を一致させる意味もある）。
+# session_note_basename <transcript_path> <is_subagent> <cache_key> <state_dir> <stamp>
+session_note_basename() {
+  local transcript="$1" is_subagent="$2" cache_key="$3" state_dir="$4" stamp="$5"
+  local cache_file="${state_dir}/${cache_key}.slug" slug branch
+
+  if [[ -s "$cache_file" ]]; then
+    slug="$(cat "$cache_file")"
+  else
+    slug="$(summarize_slug "$transcript" "$is_subagent")"
+    printf '%s' "$slug" > "$cache_file"
+  fi
+
+  branch="$(note_branch "$transcript")"
+  if [[ -n "$branch" ]]; then
+    printf '%s_%s_%s' "$stamp" "$branch" "$slug"
+  else
+    printf '%s_%s' "$stamp" "$slug"
+  fi
 }
 
 # ノートを月別フォルダに分けるための YYYYMM を stamp (または ISO timestamp)
@@ -53,6 +129,16 @@ resolve_project() {
   [[ -z "$session_cwd" ]] && session_cwd="$2"
   git_root="$(git -C "$session_cwd" rev-parse --show-toplevel 2>/dev/null || true)"
   basename "${git_root:-$session_cwd}"
+}
+
+# 冪等性・キャッシュ用のマシンローカル state ディレクトリを返す
+# (このリポジトリの管理対象外＝git管理されないマシンローカル状態)。
+# log-to-obsidian.sh の行番号カウンタ (*.count) と
+# session_note_basename の要約キャッシュ (*.slug) を両方ここに置く。
+obsidian_state_dir() {
+  local dir="$HOME/.claude/claude-obsidian-log"
+  mkdir -p "$dir"
+  printf '%s' "$dir"
 }
 
 # vault のルートを Obsidian の vault レジストリから解決する。

--- a/.claude/hooks/sync-tasks-to-obsidian.sh
+++ b/.claude/hooks/sync-tasks-to-obsidian.sh
@@ -9,7 +9,8 @@
 # タスク削除（JSON ファイルの消滅）も自動で反映される。
 #
 # ノートは ClaudeCode/<project>/Tasks/<YYYYMM>/<session_id>/ 配下に
-# <stamp>_<slug>.md として置き、冒頭でセッションログノート
+# <stamp>_<branch>_<slug>.md (session_note_basename の出力) として置き、
+# 冒頭でセッションログノート
 # (ClaudeCode/<project>/Conversations/<YYYYMM>/ 配下) へ wikilink する。
 # タスクノートとセッションログノートは basename が同一（suffix なし）で
 # 衝突するため、リンクは basename ではなく vault ルートからのフルパスで
@@ -83,13 +84,14 @@ fi
 project="$(resolve_project "$session_transcript" "$cwd")"
 started_at="$(jq -rn 'first(inputs | .timestamp // empty)' "$session_transcript")"
 stamp="$(note_stamp "$started_at")"
-slug="$(note_slug "$session_transcript" false)"
-[[ -n "$stamp" && -n "$slug" ]] || exit 0
+[[ -n "$stamp" ]] || exit 0
 
 vault_root="$(resolve_vault_root)"
 [[ -n "$vault_root" && -d "$vault_root" ]] || exit 0
 
-session_note="${stamp}_${slug}"
+state_dir="$(obsidian_state_dir)"
+session_note="$(session_note_basename "$session_transcript" false "$session_id" "$state_dir" "$stamp")"
+[[ -n "$session_note" ]] || exit 0
 yyyymm="$(note_yyyymm "$stamp")"
 conv_note="ClaudeCode/${project}/Conversations/${yyyymm}/${session_note}"
 note_file="$vault_root/ClaudeCode/${project}/Tasks/${yyyymm}/${session_id}/${session_note}.md"


### PR DESCRIPTION
## Summary
- Obsidian セッションログのファイル名が `{stamp}_{先頭30文字}.md` のままだと、同一プロジェクト内で似た書き出しのセッションが見分けづらかったため改善
- `{stamp}_{branch}_{slug}.md` 形式に変更。slug は `claude -p --safe-mode --no-session-persistence`（hooks無効・非永続）で先頭ユーザー発言を25文字以内に要約したものを使用し、失敗時は従来の先頭30文字切り出しにフォールバック
- 要約は session_id ごとに `~/.claude/claude-obsidian-log/<key>.slug` にキャッシュし、Claude呼び出しをセッションにつき1回に抑制。log-to-obsidian.sh / sync-tasks-to-obsidian.sh 間で basename が一致するよう `obsidian-note-lib.sh` に一元化

## Test plan
- [x] `bash -n` で3ファイルとも構文チェック
- [x] ダミー transcript で `session_note_basename` を実行し、1回目は実際に `claude -p` を呼んで要約を取得（約20秒）、2回目はキャッシュヒットで即時に同じ結果を確認
- [x] hooks のデフォルトタイムアウト(600秒)が20秒程度のClaude呼び出しに対して十分であることを確認
- [ ] 実運用（実セッション）でのノート生成を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)