### PR TITLE
feat(nvim): statusline を全幅表示にし DiffOrig キーバインドを追加

### DIFF
--- a/.config/nvim/lua/config/key-bindings.lua
+++ b/.config/nvim/lua/config/key-bindings.lua
@@ -17,6 +17,9 @@ end, { desc = "Clear search + LSP highlights" })
 vim.keymap.set("n", "<leader>q", "<cmd>cclose<CR>", { desc = "Close quickfix" })
 vim.keymap.set("n", "<leader>l", "<cmd>lclose<CR>", { desc = "Close loclist" })
 
+-- Diff unsaved buffer against the file on disk
+vim.keymap.set("n", "<leader>do", "<cmd>DiffOrig<CR>", { desc = "Diff: buffer vs saved file" })
+
 -- IME切り替え(Ctrl+Shift+S)が端末のフロー制御解除により生の^Sとして
 -- コマンドライン(検索含む)に紛れ込むのを防ぐ
 vim.keymap.set("c", "<C-s>", "<Nop>", { desc = "Ignore stray ^S in cmdline" })

--- a/.config/nvim/lua/plugins/lualine.lua
+++ b/.config/nvim/lua/plugins/lualine.lua
@@ -6,6 +6,19 @@ return {
     require("lualine").setup({
       options = {
         theme = "tokyonight",
+        -- statusline を window ごとではなく画面全幅の 1 本にする (laststatus=3)。
+        -- split で window が狭くてもブランチ名やファイル名が潰れない。
+        -- 各 window のファイル名表示は incline が担当している
+        globalstatus = true,
+      },
+      sections = {
+        lualine_b = { "branch", "diff", "diagnostics" },
+        lualine_c = {
+          -- 全幅になった分、ファイル名は相対パス付きで表示
+          { "filename", path = 1 },
+        },
+        -- 検索カウント [3/14] を常時表示 (nohlsearch で消える)
+        lualine_x = { "searchcount", "encoding", "fileformat", "filetype" },
       },
     })
   end,


### PR DESCRIPTION
## Summary
- lualine に `globalstatus` を設定し、window 分割時も branch/filename が潰れないようにした
- lualine_c を相対パス表示に、lualine_x に `searchcount` を追加
- `<leader>do` でバッファと保存済みファイルの差分を確認できるキーバインドを追加

## Test plan
- [ ] nvim を起動し window を分割した状態で statusline が画面全幅で 1 本になっていることを確認
- [ ] 検索実行時に `[n/N]` のカウントが statusline に表示されることを確認
- [ ] `<leader>do` でバッファと保存済みファイルの diff が開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)