### PR TITLE
feat: pr-comments スキル追加・alacritty の ATOK 自動切替・claude 設定調整

### DIFF
--- a/.claude/hooks/sync-tasks-to-obsidian.sh
+++ b/.claude/hooks/sync-tasks-to-obsidian.sh
@@ -8,7 +8,7 @@
 # ディレクトリ全体を読み直してノートを全量書き換える。差分追跡が不要になり、
 # タスク削除（JSON ファイルの消滅）も自動で反映される。
 #
-# ノートは ClaudeCode/<project>/Tasks/<YYYYMM>/<session_id>/ 配下に
+# ノートは ClaudeCode/<project>/Tasks/<YYYYMM>/ 配下に
 # <stamp>_<branch>_<slug>.md (session_note_basename の出力) として置き、
 # 冒頭でセッションログノート
 # (ClaudeCode/<project>/Conversations/<YYYYMM>/ 配下) へ wikilink する。
@@ -94,7 +94,7 @@ session_note="$(session_note_basename "$session_transcript" false "$session_id" 
 [[ -n "$session_note" ]] || exit 0
 yyyymm="$(note_yyyymm "$stamp")"
 conv_note="ClaudeCode/${project}/Conversations/${yyyymm}/${session_note}"
-note_file="$vault_root/ClaudeCode/${project}/Tasks/${yyyymm}/${session_id}/${session_note}.md"
+note_file="$vault_root/ClaudeCode/${project}/Tasks/${yyyymm}/${session_note}.md"
 mkdir -p "$(dirname "$note_file")"
 
 tmp_file="$(mktemp "${note_file}.XXXXXX")"

--- a/.claude/hooks/test-sync-tasks-to-obsidian.sh
+++ b/.claude/hooks/test-sync-tasks-to-obsidian.sh
@@ -137,7 +137,7 @@ note_count() {
   find "$VAULT_DIR" -name '*.md' -type f | wc -l | tr -d ' '
 }
 
-NOTE_REL="ClaudeCode/myproject/Tasks/202607/$SESSION/2026-07-02T09-00-00_タスク管理のテスト.md"
+NOTE_REL="ClaudeCode/myproject/Tasks/202607/2026-07-02T09-00-00_タスク管理のテスト.md"
 
 note_content() {
   cat "$VAULT_DIR/$NOTE_REL" 2>/dev/null
@@ -157,7 +157,7 @@ task_json 3 pending     "テストする"
 run_hook "$(hook_input)"
 
 assert_eq          "作成されるノートは1つ" "1" "$(note_count)"
-assert_file_exists "ノートは Tasks/YYYYMM/session_id/ 配下にセッションノートと同名" "$VAULT_DIR/$NOTE_REL"
+assert_file_exists "ノートは Tasks/YYYYMM/ 配下にセッションノートと同名" "$VAULT_DIR/$NOTE_REL"
 content="$(note_content)"
 assert_contains "frontmatter に session_id"        "$content" "session_id: ${SESSION}"
 assert_contains "frontmatter に project"           "$content" "project: myproject"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -106,7 +106,6 @@
             "Bash(find * -iwholename*/*)",
             "Bash(find * -ok*)",
             "Bash(find *|*xargs *)",
-            "Bash(git checkout:*)",
             "Bash(git clean:*)",
             "Bash(git config:*)",
             "Bash(git filter-branch:*)",
@@ -146,10 +145,6 @@
     },
     "model": "claude-fable-5[1m]",
     "enableAllProjectMcpServers": true,
-    "statusLine": {
-        "type": "command",
-        "command": "bash ~/.claude/hooks/statusline.sh"
-    },
     "hooks": {
         "PreToolUse": [
             {
@@ -211,6 +206,10 @@
                 ]
             }
         ]
+    },
+    "statusLine": {
+        "type": "command",
+        "command": "bash ~/.claude/hooks/statusline.sh"
     },
     "effortLevel": "high",
     "tui": "fullscreen",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -66,6 +66,7 @@
             "Bash(obsidian tasks:*)",
             "Bash(obsidian task:*)",
             "Bash(obsidian open:*)",
+            "Bash(obsidian help:*)",
             "Bash(ps:*)",
             "Bash(pwd:*)",
             "Bash(rg:*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -81,6 +81,7 @@
             "Bash(which:*)",
             "Bash(~/.claude/skills/code-review/scripts/codex-review.sh:*)",
             "Bash(~/.claude/skills/code-review/scripts/check-prereqs.sh:*)",
+            "Bash(~/.claude/skills/pr-comments/scripts/fetch-pr-comments.sh:*)",
             "Bash(codex:*)",
             "Bash(whoami:*)",
             "mcp__context7__get-library-docs",

--- a/.claude/skills/pr-comments/SKILL.md
+++ b/.claude/skills/pr-comments/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: pr-comments
+description: "GitHub PR のレビューコメントの洗い出しとタスク化。固定スクリプトで reviews / review threads / issue comments をまとめて取得し、分類して Obsidian のタスクノートに書き出す。「PR コメントをリストアップして」「レビューコメントをタスク化して」「PR の指摘を洗い出して」と言われたときに起動。"
+allowed-tools: Bash(~/.claude/skills/pr-comments/scripts/fetch-pr-comments.sh:*), Bash(gh pr view:*), Bash(git rev-parse:*), Bash(date:*), Bash(obsidian read:*), Bash(obsidian create:*), Bash(obsidian files:*), Bash(obsidian open:*)
+---
+
+# PR Comments — レビューコメントの洗い出しとタスク化
+
+GitHub PR に付いたコメントを固定スクリプトで一括取得し、分類・一覧化して Obsidian のタスクノートに書き出す。`gh api` + インライン Python をその場で組み立てるのは禁止（毎回承認が必要になる）。取得は必ず下記スクリプトで行う。
+
+## 手順
+
+### 1. コメント取得
+
+```bash
+~/.claude/skills/pr-comments/scripts/fetch-pr-comments.sh [PR番号 | PR URL] [オプション]
+```
+
+- 引数省略時はカレントブランチの PR を自動解決する
+- ユーザーが「このレビュー以降」と URL を貼った場合、`#pullrequestreview-<ID>` の ID を `--since <ID>` に渡す（その review 自身を含む）。日時指定なら ISO8601 も可
+- 解決済み (resolved) スレッドはデフォルトで除外される。全件見たいと言われたら `--include-resolved`
+- 出力はデフォルト JSON。`--format md` で人間向け Markdown
+
+### 2. 分類して一覧提示
+
+タスク化の前に、必ず一覧をユーザーに提示する。
+
+- コメント本文の先頭ラベル（`[IMO]` `[ASK]` `[NITS]` `[WANT]` `[Tweet]` `[質問]` など）を拾って分類する。ラベルが無ければ内容から «要修正 / 要回答 / 要議論 / 対応不要» を推定する
+- 各項目は「指摘者 / `path:line` / ラベル / 一行要約」で提示。「対応不要」とスレッド内で明言されているものはその旨を付記する
+- スレッドに返信が付いている場合は最新の議論状態を要約に反映する
+
+### 3. Obsidian タスクノートへ書き出し
+
+保存先: `ClaudeCode/<プロジェクト名>/Tasks/PR-<PR番号>.md`
+
+- プロジェクト名: `basename "$(git rev-parse --show-toplevel)"`（対象リポジトリの名前。dotfiles ではなく PR のリポジトリ）
+- 書き込みは obsidian CLI（connect-obsidian スキル参照）で行う。素の Write は使わない
+
+**既存ノートがある場合は先に `obsidian read` で読み、チェック済み `- [x]` の状態と手書きの追記を保持したままマージする**（`overwrite` で無断で潰さない）。
+
+フォーマット:
+
+```markdown
+---
+pr: <PR URL>
+repo: <owner/name>
+updated: <YYYY-MM-DD>
+---
+
+# PR #<番号> レビュー対応タスク
+
+## 要修正
+- [ ] `path/file.go:54` [IMO] 一行要約 — @指摘者 ([comment](URL))
+
+## 要回答・要確認
+- [ ] ...
+
+## 要議論
+- [ ] ...
+
+## 対応不要（記録のみ）
+- 一行要約 — @指摘者 ([comment](URL))
+```
+
+- 1 スレッド = 1 タスク。チェックボックスの行に `path:line`・ラベル・要約・指摘者・コメント URL を必ず含める
+- 「対応不要」セクションはチェックボックスにしない
+- 書き出し後、ノートのパスをユーザーに伝える（必要なら `obsidian open` で開く）
+
+## 注意
+
+- スクリプトは gh CLI の認証を前提とする。失敗したら stderr をそのまま提示する
+- タスク管理先の変更（TaskCreate / Notion 等）をユーザーが明示した場合のみ、そちらに切り替える

--- a/.claude/skills/pr-comments/SKILL.md
+++ b/.claude/skills/pr-comments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-comments
-description: "GitHub PR のレビューコメントの洗い出しとタスク化。固定スクリプトで reviews / review threads / issue comments をまとめて取得し、分類して Obsidian のタスクノートに書き出す。「PR コメントをリストアップして」「レビューコメントをタスク化して」「PR の指摘を洗い出して」と言われたときに起動。"
+description: "GitHub PR のレビューコメントの洗い出しとタスク化、および対応状況の更新。固定スクリプトで reviews / review threads / issue comments をまとめて取得し、分類して Obsidian のタスクノートに書き出す。「PR コメントをリストアップして」「レビューコメントをタスク化して」「PR の指摘を洗い出して」「対応状況を更新して」「ステータスを同期して」と言われたときに起動。"
 allowed-tools: Bash(~/.claude/skills/pr-comments/scripts/fetch-pr-comments.sh:*), Bash(gh pr view:*), Bash(git rev-parse:*), Bash(date:*), Bash(obsidian read:*), Bash(obsidian create:*), Bash(obsidian files:*), Bash(obsidian open:*)
 ---
 
@@ -65,6 +65,19 @@ updated: <YYYY-MM-DD>
 - 1 スレッド = 1 タスク。チェックボックスの行に `path:line`・ラベル・要約・指摘者・コメント URL を必ず含める
 - 「対応不要」セクションはチェックボックスにしない
 - 書き出し後、ノートのパスをユーザーに伝える（必要なら `obsidian open` で開く）
+
+### 4. 対応状況の更新（再実行時）
+
+「対応状況を更新して」「ステータスを同期して」と言われた場合、または既存タスクノートがある PR に対して再度洗い出しを行う場合はこちら。
+
+1. `obsidian read` で既存ノートを読み込み、各タスク行末尾の `([comment](URL))` から URL を抽出する
+2. スクリプトを `--include-resolved` 付きで再取得し、GitHub 側の最新状態を得る
+3. 既存タスクは必ずコメント URL をキーにスレッドと突き合わせる（`path:line` だけでは同じ行に複数スレッドが立つケースを区別できない）
+4. 突き合わせたスレッドが resolved なら、そのタスク行を `- [x]` に更新する（既にチェック済みならそのまま）
+5. 突き合わせたスレッドに新しい返信が付いていれば、要約の末尾に議論の要点を追記する（例: `— 返信あり: 要約`）
+6. 手動でチェック済みだが GitHub 側がまだ resolved でない行はそのまま維持する（resolved 化を強制しない。ユーザーの先行判断を優先する）
+7. 新規スレッド・新規コメントは手順2・3の分類基準に従って追記する
+8. 更新後、変更点（resolved になった件数・新規追加件数）をユーザーに要約して報告する
 
 ## 注意
 

--- a/.claude/skills/pr-comments/scripts/fetch-pr-comments.sh
+++ b/.claude/skills/pr-comments/scripts/fetch-pr-comments.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# GitHub PR のレビュー・レビュースレッド・会話コメントをまとめて取得する。
+#
+# gh CLI (認証済み) 経由で GraphQL API を叩く。REST と違い reviewThreads の
+# isResolved / isOutdated が取れるため、解決済みスレッドの除外までここで完結する。
+#
+# 使い方:
+#   fetch-pr-comments.sh [PR番号 | PR URL] [--repo owner/name]
+#                        [--since <review-id | UTC ISO8601>]
+#                        [--include-resolved] [--format json|md]
+#
+# 引数を省略した場合はカレントブランチの PR を gh pr view で解決する。
+# --since に review の databaseId を渡すと、その review の submittedAt 以降
+# (その review 自身を含む) に絞り込む。日時指定は UTC の ISO8601
+# (例: 2026-07-08T05:00:00Z, 2026-07-08) のみ。文字列比較でフィルタするため。
+set -euo pipefail
+
+usage() {
+  sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+PR_ARG="" REPO="" SINCE="" INCLUDE_RESOLVED=false FORMAT=json
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) REPO=$2; shift 2 ;;
+    --since) SINCE=$2; shift 2 ;;
+    --include-resolved) INCLUDE_RESOLVED=true; shift ;;
+    --format) FORMAT=$2; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "不明なオプション: $1" >&2; exit 1 ;;
+    *) PR_ARG=$1; shift ;;
+  esac
+done
+if [ "$FORMAT" != json ] && [ "$FORMAT" != md ]; then
+  echo "--format は json か md: $FORMAT" >&2; exit 1
+fi
+
+# --- PR の解決 (番号・URL・引数なしのいずれも gh pr view に任せる) ---
+view_args=(pr view --json url,title,number)
+[ -n "$PR_ARG" ] && view_args=(pr view "$PR_ARG" --json url,title,number)
+[ -n "$REPO" ] && view_args+=(--repo "$REPO")
+pr_info=$(gh "${view_args[@]}")
+PR_URL=$(jq -r .url <<<"$pr_info")
+TITLE=$(jq -r .title <<<"$pr_info")
+if [[ $PR_URL =~ github\.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+  OWNER=${BASH_REMATCH[1]} NAME=${BASH_REMATCH[2]} NUMBER=${BASH_REMATCH[3]}
+else
+  echo "PR URL を解釈できません: $PR_URL" >&2; exit 1
+fi
+
+# --- GraphQL 取得 (gh の --paginate は $endCursor + pageInfo が必須) ---
+REVIEWS_QUERY='query($owner:String!,$name:String!,$number:Int!,$endCursor:String){
+  repository(owner:$owner,name:$name){ pullRequest(number:$number){
+    reviews(first:50, after:$endCursor){
+      pageInfo{hasNextPage endCursor}
+      nodes{ databaseId author{login} state body submittedAt url }
+    } } } }'
+
+THREADS_QUERY='query($owner:String!,$name:String!,$number:Int!,$endCursor:String){
+  repository(owner:$owner,name:$name){ pullRequest(number:$number){
+    reviewThreads(first:50, after:$endCursor){
+      pageInfo{hasNextPage endCursor}
+      nodes{ isResolved isOutdated path line
+        comments(first:100){ nodes{
+          author{login} body createdAt url pullRequestReview{databaseId}
+        } } }
+    } } } }'
+
+ISSUE_COMMENTS_QUERY='query($owner:String!,$name:String!,$number:Int!,$endCursor:String){
+  repository(owner:$owner,name:$name){ pullRequest(number:$number){
+    comments(first:100, after:$endCursor){
+      pageInfo{hasNextPage endCursor}
+      nodes{ author{login} body createdAt url }
+    } } } }'
+
+fetch_nodes() {
+  # $1: クエリ, $2: pullRequest 直下の connection 名。全ページの nodes を連結して返す
+  gh api graphql --paginate \
+    -f query="$1" -f owner="$OWNER" -f name="$NAME" -F number="$NUMBER" \
+    --jq ".data.repository.pullRequest.$2.nodes" | jq -s 'add // []'
+}
+
+reviews=$(fetch_nodes "$REVIEWS_QUERY" reviews)
+threads=$(fetch_nodes "$THREADS_QUERY" reviewThreads)
+issue_comments=$(fetch_nodes "$ISSUE_COMMENTS_QUERY" comments)
+
+# --- --since の解決 ---
+SINCE_TIME=""
+if [ -n "$SINCE" ]; then
+  if [[ $SINCE =~ ^[0-9]+$ ]]; then
+    SINCE_TIME=$(jq -r --argjson id "$SINCE" \
+      '[.[] | select(.databaseId == $id)][0].submittedAt // empty' <<<"$reviews")
+    if [ -z "$SINCE_TIME" ]; then
+      echo "review id $SINCE がこの PR に見つかりません" >&2; exit 1
+    fi
+  else
+    SINCE_TIME=$SINCE
+  fi
+fi
+
+# --- フィルタと整形 ---
+result=$(jq -n \
+  --argjson reviews "$reviews" \
+  --argjson threads "$threads" \
+  --argjson issue_comments "$issue_comments" \
+  --arg owner "$OWNER" --arg name "$NAME" --argjson number "$NUMBER" \
+  --arg title "$TITLE" --arg url "$PR_URL" \
+  --arg since "$SINCE" --arg since_time "$SINCE_TIME" \
+  --argjson include_resolved "$INCLUDE_RESOLVED" \
+'
+def login: .author.login // "(unknown)";
+# review コメントの createdAt は下書き記入時刻なので、公開時刻 = 所属 review の
+# submittedAt で --since を判定する (所属 review が引けなければ createdAt)
+($reviews | map({key: (.databaseId | tostring), value: .submittedAt}) | from_entries) as $review_time |
+def published_at: $review_time[.pullRequestReview.databaseId | tostring] // .createdAt;
+{
+  pr: { repo: "\($owner)/\($name)", number: $number, title: $title, url: $url },
+  since: (if $since == "" then null else $since end),
+  # 本文空の COMMENTED review はスレッドの入れ物なので除外
+  reviews: [ $reviews[]
+    | select((.body | gsub("\\s"; "") != "") or .state != "COMMENTED")
+    | select($since_time == "" or .submittedAt >= $since_time)
+    | { review_id: .databaseId, author: login, state, submitted_at: .submittedAt, body, url } ],
+  threads: [ $threads[]
+    | select($include_resolved or (.isResolved | not))
+    | select($since_time == "" or ([.comments.nodes[] | published_at] | max) >= $since_time)
+    | { path, line, resolved: .isResolved, outdated: .isOutdated,
+        comments: [ .comments.nodes[]
+          | { author: login, created_at: .createdAt, body, url,
+              review_id: .pullRequestReview.databaseId } ] } ],
+  issue_comments: [ $issue_comments[]
+    | select($since_time == "" or .createdAt >= $since_time)
+    | { author: login, created_at: .createdAt, body, url } ]
+}')
+
+if [ "$FORMAT" = json ]; then
+  printf '%s\n' "$result"
+  exit 0
+fi
+
+jq -r '
+def quote: .body // "" | rtrimstr("\n") | split("\n") | map("  > " + .) | join("\n");
+def loc: if .line then "\(.path):\(.line)" else .path end;
+def flags: [ (if .resolved then "[resolved]" else empty end),
+             (if .outdated then "[outdated]" else empty end) ]
+           | if length == 0 then "" else " " + join(" ") end;
+
+[ "# PR #\(.pr.number): \(.pr.title)", .pr.url, "" ]
++ (if (.reviews | length) > 0 then
+    ["## Reviews"]
+    + [ .reviews[] | "- **\(.state)** @\(.author) (\(.submitted_at)) \(.url)"
+        + (if (.body | gsub("\\s"; "")) != "" then "\n" + quote else "" end) ]
+    + [""]
+  else [] end)
++ (if (.threads | length) > 0 then
+    ["## Review threads (\(.threads | length))"]
+    + [ .threads[] | "### " + loc + flags + "\n"
+        + ([ .comments[] | "- @\(.author) (\(.created_at)) \(.url)\n" + quote ] | join("\n"))
+        + "\n" ]
+  else [] end)
++ (if (.issue_comments | length) > 0 then
+    ["## Issue comments"]
+    + [ .issue_comments[] | "- @\(.author) (\(.created_at)) \(.url)\n" + quote ]
+    + [""]
+  else [] end)
+| join("\n")
+' <<<"$result"

--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -40,6 +40,23 @@ key = "S"
 mods = "Control|Alt"
 action = "None"
 
+# tmux leader (Ctrl-p) を押した瞬間に ATOK を英字モードに強制切り替えしてから
+# Ctrl-p を pty に転送する。tmux のプレフィックスキー入力中に IME が有効なままだと
+# 後続のキー入力が誤変換されるのを防ぐ。
+# ATOK は「あ」「英字」を独立した入力ソースではなく単一ソース内のモードとして
+# 扱っているため、`com.apple.keylayout.ABC` (別の入力ソース) ではなく
+# ATOK 内の英字モード ID `com.justsystems.inputmethod.atok35.Roman` を指定する
+# (`im-select` を英字モード中に引数なし実行して確認した実際の ID)。
+[[keyboard.bindings]]
+key = "P"
+mods = "Control"
+command = { program = "/opt/homebrew/bin/im-select", args = ["com.justsystems.inputmethod.atok35.Roman"] }
+
+[[keyboard.bindings]]
+key = "P"
+mods = "Control"
+chars = "\u0010"
+
 [bell]
 animation = "Ease"
 duration = 150

--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,5 @@
+tap "daipeihust/tap"
+
 brew "awscli"
 brew "bat"
 brew "eza"
@@ -9,6 +11,7 @@ brew "gh"
 brew "ghq"
 brew "git-delta"
 brew "gnu-sed"
+brew "daipeihust/tap/im-select"
 brew "iproute2mac"
 brew "jq"
 brew "lazygit"


### PR DESCRIPTION
## 概要

溜まっていた変更を 3 コミットに区切ってまとめた PR。

### feat(skills): pr-comments スキルを追加

GitHub PR のレビューコメントの洗い出しとタスク化をワークフロー化。

- `gh api graphql --paginate` を使う固定スクリプト (`fetch-pr-comments.sh`) で reviews / review threads / issue comments を一括取得。都度承認が必要だったインライン Python の組み立てを排除
- `--since <review-id|日時>` はコメントの公開時刻 (所属 review の `submittedAt`) で判定。`createdAt` は下書き記入時刻のため submit 前のレビューコメントが漏れる問題への対処
- resolved スレッドはデフォルト除外 (`--include-resolved` で含める)
- SKILL.md にラベル分類 (`[IMO]/[ASK]/[NITS]` 等) → Obsidian `ClaudeCode/<project>/Tasks/PR-<番号>.md` への書き出し手順を定義
- settings.json の allow にスクリプトのパスを追加 (実 PR sansaninc/auth-one#2685 で取得結果を検証済み)

### feat(alacritty): tmux prefix 入力時に ATOK を英字モードへ切替

- Ctrl-p 押下時に im-select で ATOK の英字モード (`atok35.Roman`) へ強制切替してから Ctrl-p を pty へ転送し、prefix 後のキー入力の誤変換を防ぐ
- Brewfile に `daipeihust/tap/im-select` を追加

### chore(claude): settings.json の調整

- deny から `git checkout` を削除 (ブランチ作成・切替に使えるようにする。`git switch` は deny のまま)
- statusLine ブロックを hooks の後ろへ移動 (並び整理のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)