### PR TITLE
feat(nvim): インデント可視化に indent-blankline と hlchunk を追加

### DIFF
--- a/.config/nvim/lua/config/options.lua
+++ b/.config/nvim/lua/config/options.lua
@@ -18,7 +18,8 @@ local options = {
 	signcolumn = "yes",
 	list = true,
 	listchars = {
-		space = "·",
+		-- space は指定しない: 行頭の空白が全部ドットで埋まり
+		-- indent-blankline のインデントガイドと二重表示になるため
 		tab = "»·",
 		eol = "↴",
 		extends = "›",

--- a/.config/nvim/lua/plugins/indent.lua
+++ b/.config/nvim/lua/plugins/indent.lua
@@ -1,0 +1,86 @@
+-- インデントの可視化
+-- ibl: インデントレベルごとに色を変えたガイド線 (VSCode の indent rainbow 相当)
+-- hlchunk: カーソルのいるブロックを枠線で囲む (VSCode の Blockman 相当)
+
+-- tokyonight moon のパレット (lua/plugins/colorscheme.lua と揃える)
+local rainbow = {
+  IndentRainbowRed = "#ff757f",
+  IndentRainbowOrange = "#ff966c",
+  IndentRainbowYellow = "#ffc777",
+  IndentRainbowGreen = "#c3e88d",
+  IndentRainbowCyan = "#86e1fc",
+  IndentRainbowBlue = "#82aaff",
+  IndentRainbowPurple = "#c099ff",
+}
+
+-- インデントの深さの順に適用される
+local highlight = {
+  "IndentRainbowRed",
+  "IndentRainbowOrange",
+  "IndentRainbowYellow",
+  "IndentRainbowGreen",
+  "IndentRainbowCyan",
+  "IndentRainbowBlue",
+  "IndentRainbowPurple",
+}
+
+return {
+  {
+    "lukas-reineke/indent-blankline.nvim",
+    main = "ibl",
+    event = { "BufReadPost", "BufNewFile" },
+    config = function()
+      local hooks = require("ibl.hooks")
+
+      -- colorscheme の切り替えで消えないよう HIGHLIGHT_SETUP フックで定義する
+      hooks.register(hooks.type.HIGHLIGHT_SETUP, function()
+        for name, fg in pairs(rainbow) do
+          vim.api.nvim_set_hl(0, name, { fg = fg })
+        end
+      end)
+
+      require("ibl").setup({
+        indent = {
+          char = "▏",
+          highlight = highlight,
+        },
+        -- 現在スコープの表示は hlchunk の枠線に任せる (二重に強調すると煩いため)
+        scope = { enabled = false },
+        exclude = {
+          filetypes = {
+            "help",
+            "lazy",
+            "neo-tree",
+            "Trouble",
+            "lazygit",
+            "octo",
+            "markdown",
+          },
+        },
+      })
+    end,
+  },
+  {
+    "shellRaining/hlchunk.nvim",
+    event = { "BufReadPost", "BufNewFile" },
+    config = function()
+      require("hlchunk").setup({
+        chunk = {
+          enable = true,
+          style = {
+            { fg = "#82aaff" }, -- 通常
+            { fg = "#ff757f" }, -- 括弧が閉じていないとき
+          },
+          exclude_filetypes = {
+            help = true,
+            lazy = true,
+            ["neo-tree"] = true,
+            octo = true,
+            markdown = true,
+          },
+        },
+        -- indent / blank / line_num は ibl と役割が重複するので無効のまま
+      })
+    end,
+  },
+}


### PR DESCRIPTION
## 概要

nvim のインデント表示を見やすくするため、VSCode の indent rainbow / Blockman 相当の可視化を導入する。

## 変更内容

`lua/plugins/indent.lua` を新規追加し、2 つのプラグインで役割を分担させる。

- **indent-blankline (ibl)** — インデントレベルごとに色を変えたガイド線を描画する（indent rainbow 相当）。色は tokyonight moon のパレットに揃え、colorscheme の切り替えで消えないよう `HIGHLIGHT_SETUP` フックで定義する。現在スコープの表示は hlchunk に任せるため `scope` は無効にする
- **hlchunk** — カーソルのいるブロックを枠線で囲む（Blockman 相当）。`indent` / `blank` / `line_num` は ibl と役割が重複するので無効のままにする

あわせて `lua/config/options.lua` の `listchars` から `space` を外す。行頭の空白が全部ドットで埋まり、インデントガイドと二重に表示されて見づらくなるため。

## 動作確認

未実施。マージ後に nvim を起動して `:Lazy sync` し、実際の表示を確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)