### PR TITLE
feat: nix セットアップの自動化と work プロファイルの実機対応

### DIFF
--- a/.zshenv.sample
+++ b/.zshenv.sample
@@ -2,6 +2,12 @@ setopt no_global_rcs
 
 typeset -U path PATH
 path=(
+	# nix (no_global_rcs で /etc/zshrc を読まないので自前で通す)。
+	# home-manager (useUserPackages) → nix-darwin → nix 本体 の順。
+	# brew より前に置かないと同名コマンドで brew 版が勝つ。
+	/etc/profiles/per-user/$USERNAME/bin(N-/)
+	/run/current-system/sw/bin(N-/)
+	/nix/var/nix/profiles/default/bin(N-/)
 	/opt/homebrew/bin(N-/)
 	/opt/homebrew/sbin(N-/)
 	/usr/local/bin(N-/)

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,24 @@ DOTFILES_DIR := $(shell cd "$(dir $(lastword $(MAKEFILE_LIST)))" && pwd)
 NIX_DARWIN_DIR := $(DOTFILES_DIR)/nix/nix-darwin
 LINK_SH := $(DOTFILES_DIR)/scripts/link.sh
 
+NIX_INSTALLER_URL := https://artifacts.nixos.org/nix-installer
+NIX_DAEMON_SH := /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+# 初回 activate 前は /etc/nix/nix.conf に flakes が入っていないので明示的に有効化する。
+NIX_FLAGS := --extra-experimental-features 'nix-command flakes'
+
+# make のレシピは (継続行を含む) 1 行ごとに別シェルなので、nix を使うコマンドの
+# 直前で毎回これを挟む。install-nix の直後など、呼び出し元シェルの PATH に
+# まだ nix が入っていない状態でも同一 make 実行内で続行できるようにするため。
+LOAD_NIX = if ! command -v nix >/dev/null 2>&1 && [ -e $(NIX_DAEMON_SH) ]; then . $(NIX_DAEMON_SH); fi
+
 # personal | work
 PROFILE ?= personal
 
 .DEFAULT_GOAL := help
-.PHONY: help setup link link-dry rebuild dry-run doctor
+.PHONY: help setup install-nix link link-dry rebuild dry-run doctor
 
-# setup は link → rebuild の順序に意味がある (link が Homebrew 本体を用意し、
-# rebuild がその上に cask/brew を宣言的に入れる) ため並列実行させない。
+# setup は install-nix → link → rebuild の順序に意味がある (link が Homebrew 本体を
+# 用意し、rebuild がその上に cask/brew を宣言的に入れる) ため並列実行させない。
 .NOTPARALLEL:
 
 help:
@@ -17,26 +27,37 @@ help:
 	@echo "  dotfiles"
 	@echo "========================================="
 	@echo ""
-	@echo "  make setup      - 初回セットアップ (前提チェック → link → rebuild)"
-	@echo "  make link       - symlink 作成 + Homebrew 準備 (scripts/link.sh)"
-	@echo "  make link-dry   - link の内容を表示するだけ (何も変更しない)"
-	@echo "  make rebuild    - darwin-rebuild switch (PROFILE=personal|work, default: personal)"
-	@echo "  make dry-run    - darwin-rebuild の評価だけ確認 (activate しない)"
-	@echo "  make doctor     - 前提コマンドと symlink の状態を確認"
+	@echo "  make setup       - 初回セットアップ (install-nix → link → rebuild)"
+	@echo "  make install-nix - nix 本体をインストール (導入済みなら何もしない)"
+	@echo "  make link        - symlink 作成 + Homebrew 準備 (scripts/link.sh)"
+	@echo "  make link-dry    - link の内容を表示するだけ (何も変更しない)"
+	@echo "  make rebuild     - darwin-rebuild switch (PROFILE=personal|work, default: personal)"
+	@echo "  make dry-run     - darwin-rebuild の評価だけ確認 (activate しない)"
+	@echo "  make doctor      - 前提コマンドと symlink の状態を確認"
 	@echo ""
 	@echo "  例: make rebuild PROFILE=work"
 	@echo ""
 
-# nix 本体だけは自動インストールしない (sudo と再ログインが必要なため案内に留める)。
 setup:
-	@command -v nix >/dev/null 2>&1 || { \
-		echo "nix が見つかりません。先に Determinate Systems のインストーラを実行してください:"; \
-		echo "  curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install"; \
-		echo "インストール後、シェルを開き直してから make setup を再実行してください。"; \
-		exit 1; \
-	}
+	@$(MAKE) install-nix
 	@$(MAKE) link
 	@$(MAKE) rebuild PROFILE=$(PROFILE)
+
+# インストーラは途中で sudo と対話確認を求めるので、非対話実行には向かない。
+# 完了後もこの make を起動したシェルには PATH が通らないため、後続ターゲットは
+# $(LOAD_NIX) で nix-daemon.sh を読む。新しいシェルでは /etc/zshrc 経由で通る
+# (~/.zshenv に no_global_rcs を書いている場合は自分で path に足すこと)。
+install-nix:
+	@if command -v nix >/dev/null 2>&1; then \
+		echo "  [OK]   nix ($$(command -v nix))"; \
+	elif [ -e $(NIX_DAEMON_SH) ]; then \
+		echo "  [OK]   nix (インストール済み。このシェルには未反映)"; \
+	else \
+		echo "nix をインストールします ($(NIX_INSTALLER_URL))"; \
+		curl -sSfL $(NIX_INSTALLER_URL) | sh -s -- install; \
+		echo ""; \
+		echo "今のシェルで nix を使うには: . $(NIX_DAEMON_SH)"; \
+	fi
 
 link:
 	@$(LINK_SH)
@@ -44,11 +65,21 @@ link:
 link-dry:
 	@$(LINK_SH) --dry-run
 
+# 初回は darwin-rebuild がまだ存在しないので、flake.lock で固定している nix-darwin を
+# build して、その中の darwin-rebuild で activate する (2 回目以降は PATH のものを使う)。
 rebuild:
-	@sudo darwin-rebuild switch --flake $(NIX_DARWIN_DIR)#$(PROFILE)
+	@$(LOAD_NIX); \
+	if command -v darwin-rebuild >/dev/null 2>&1; then \
+		sudo darwin-rebuild switch --flake $(NIX_DARWIN_DIR)#$(PROFILE); \
+	else \
+		echo "darwin-rebuild が無いので初回ブートストラップします (PROFILE=$(PROFILE))"; \
+		out="$$(nix $(NIX_FLAGS) build --no-link --print-out-paths $(NIX_DARWIN_DIR)#darwinConfigurations.$(PROFILE).system)" && \
+		sudo "$$out/sw/bin/darwin-rebuild" switch --flake $(NIX_DARWIN_DIR)#$(PROFILE); \
+	fi
 
 dry-run:
-	@nix build $(NIX_DARWIN_DIR)#darwinConfigurations.$(PROFILE).system --dry-run
+	@$(LOAD_NIX); \
+	nix $(NIX_FLAGS) build $(NIX_DARWIN_DIR)#darwinConfigurations.$(PROFILE).system --dry-run
 
 doctor:
 	@echo "--- 前提コマンド ---"

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,18 @@ NIX_FLAGS := --extra-experimental-features 'nix-command flakes'
 # まだ nix が入っていない状態でも同一 make 実行内で続行できるようにするため。
 LOAD_NIX = if ! command -v nix >/dev/null 2>&1 && [ -e $(NIX_DAEMON_SH) ]; then . $(NIX_DAEMON_SH); fi
 
-# personal | work
-PROFILE ?= personal
+# PROFILE を取り違えると別マシン向けの設定を activate してしまうので、デフォルト値は
+# 持たず毎回明示させる。指定可能な値は hosts/*.nix のファイル名から拾う。
+PROFILES := $(notdir $(basename $(wildcard $(NIX_DARWIN_DIR)/hosts/*.nix)))
+CHECK_PROFILE = \
+	if [ -z "$(PROFILE)" ]; then \
+		echo "PROFILE を指定してください (指定可能: $(PROFILES))"; \
+		echo "  例: make rebuild PROFILE=work"; \
+		exit 1; \
+	elif ! echo " $(PROFILES) " | grep -q " $(PROFILE) "; then \
+		echo "不明な PROFILE: $(PROFILE) (指定可能: $(PROFILES))"; \
+		exit 1; \
+	fi
 
 .DEFAULT_GOAL := help
 .PHONY: help setup install-nix link link-dry rebuild dry-run doctor
@@ -27,18 +37,20 @@ help:
 	@echo "  dotfiles"
 	@echo "========================================="
 	@echo ""
-	@echo "  make setup       - 初回セットアップ (install-nix → link → rebuild)"
+	@echo "  make setup       - 初回セットアップ (install-nix → link → rebuild) *PROFILE 必須"
 	@echo "  make install-nix - nix 本体をインストール (導入済みなら何もしない)"
 	@echo "  make link        - symlink 作成 + Homebrew 準備 (scripts/link.sh)"
 	@echo "  make link-dry    - link の内容を表示するだけ (何も変更しない)"
-	@echo "  make rebuild     - darwin-rebuild switch (PROFILE=personal|work, default: personal)"
-	@echo "  make dry-run     - darwin-rebuild の評価だけ確認 (activate しない)"
+	@echo "  make rebuild     - darwin-rebuild switch *PROFILE 必須"
+	@echo "  make dry-run     - darwin-rebuild の評価だけ確認 (activate しない) *PROFILE 必須"
 	@echo "  make doctor      - 前提コマンドと symlink の状態を確認"
 	@echo ""
+	@echo "  PROFILE にデフォルトは無い。指定可能: $(PROFILES)"
 	@echo "  例: make rebuild PROFILE=work"
 	@echo ""
 
 setup:
+	@$(CHECK_PROFILE)
 	@$(MAKE) install-nix
 	@$(MAKE) link
 	@$(MAKE) rebuild PROFILE=$(PROFILE)
@@ -68,6 +80,7 @@ link-dry:
 # 初回は darwin-rebuild がまだ存在しないので、flake.lock で固定している nix-darwin を
 # build して、その中の darwin-rebuild で activate する (2 回目以降は PATH のものを使う)。
 rebuild:
+	@$(CHECK_PROFILE)
 	@$(LOAD_NIX); \
 	if command -v darwin-rebuild >/dev/null 2>&1; then \
 		sudo darwin-rebuild switch --flake $(NIX_DARWIN_DIR)#$(PROFILE); \
@@ -78,6 +91,7 @@ rebuild:
 	fi
 
 dry-run:
+	@$(CHECK_PROFILE)
 	@$(LOAD_NIX); \
 	nix $(NIX_FLAGS) build $(NIX_DARWIN_DIR)#darwinConfigurations.$(PROFILE).system --dry-run
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ neovim 本体は `home.packages` で入れるだけに留めている。
 ## Install
 
 ```sh
-make setup       # 初回。install-nix → link → rebuild
+make setup PROFILE=work  # 初回。install-nix → link → rebuild
 make install-nix # nix 本体のインストール (導入済みなら何もしない)
 make link        # symlink 作成 + Homebrew 本体の準備
 make link-dry    # 何も変更せず、実行内容だけ表示
@@ -89,10 +89,15 @@ Packages are declared in Nix and applied with `darwin-rebuild`.
 適用:
 
 ```sh
-make rebuild                  # PROFILE=personal (デフォルト)
+make rebuild PROFILE=personal
 make rebuild PROFILE=work
-make dry-run                  # activate せず評価だけ確認
+make dry-run PROFILE=work     # activate せず評価だけ確認
 ```
+
+`PROFILE` にデフォルトは無く、`setup` / `rebuild` / `dry-run` では指定が必須
+(取り違えると別マシン向けの設定を activate してしまうため)。指定できる値は
+`nix/nix-darwin/hosts/*.nix` のファイル名から自動で拾っており、未指定・不正な値は
+実行前にエラーで止まる。
 
 または直接:
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,25 @@ neovim 本体は `home.packages` で入れるだけに留めている。
 ## Install
 
 ```sh
-make setup      # 初回。前提チェック → link → rebuild
-make link       # symlink 作成 + Homebrew 本体の準備
-make link-dry   # 何も変更せず、実行内容だけ表示
-make doctor     # 前提コマンドと symlink の状態を確認
+make setup       # 初回。install-nix → link → rebuild
+make install-nix # nix 本体のインストール (導入済みなら何もしない)
+make link        # symlink 作成 + Homebrew 本体の準備
+make link-dry    # 何も変更せず、実行内容だけ表示
+make doctor      # 前提コマンドと symlink の状態を確認
 ```
 
-`make help` で全ターゲットを表示する。nix 本体だけは自動インストールしないので、
-未導入の場合は `make setup` が案内するインストーラを先に実行する。
+`make help` で全ターゲットを表示する。
+
+nix 本体は `make install-nix` (公式インストーラ `https://artifacts.nixos.org/nix-installer`)
+が入れる。インストーラは sudo と対話確認を求めるので非対話実行はできない。完了しても
+起動中のシェルには PATH が通らないため、`rebuild` / `dry-run` は実行前に
+`/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh` を読む。新しいシェルでは
+`/etc/zshrc` 経由で通るが、`~/.zshenv` に `setopt no_global_rcs` を書いている場合は
+読まれないので `.zshenv.sample` のように `path` へ自分で足すこと。
+
+初回は `darwin-rebuild` がまだ無いので、`make rebuild` は flake.lock で固定した
+nix-darwin を build してその中の `darwin-rebuild` で activate する。2 回目以降は
+PATH 上のものを使う。
 
 symlink 作成の実体は `scripts/link.sh`。単体実行 (`scripts/link.sh`,
 `scripts/link.sh --dry-run`) もできる。リンク元はスクリプト自身の場所から

--- a/nix/nix-darwin/flake.nix
+++ b/nix/nix-darwin/flake.nix
@@ -40,8 +40,7 @@
     in {
       darwinConfigurations = {
         personal = mkSystem { profile = "personal"; username = "yopiyama"; };
-        # 実際の macOS アカウント名が判明したら username を更新する
-        work = mkSystem { profile = "work"; username = "yopiyama"; };
+        work = mkSystem { profile = "work"; username = "yoshiyama"; };
       };
     };
 }

--- a/nix/nix-darwin/hosts/work.nix
+++ b/nix/nix-darwin/hosts/work.nix
@@ -1,8 +1,23 @@
-{ ... }:
+{ pkgs, username, ... }:
 
 {
-  # 仕事用 Mac 固有の設定。導入時にここへ差分 (追加 cask / package 等) を書く。
+  # 仕事用 Mac 固有の設定。
   # homebrew.casks / homebrew.brews はリスト型オプションなので、
-  # homebrew.nix の共通設定と自動でマージされる (++ で結合される)。例:
-  # homebrew.casks = [ "datagrip" ];
+  # homebrew.nix の共通設定と自動でマージされる (++ で結合される)。
+
+  # 仕事用 Mac だけで使うパッケージ。両方の Mac で使うものは home-manager/home.nix へ。
+  home-manager.users.${username}.home.packages = with pkgs; [
+    gemini-cli
+    # aws ssm start-session が PATH から呼ぶ session-manager-plugin 本体
+    # (Homebrew の cask session-manager-plugin と同じもの)。
+    ssm-session-manager-plugin
+  ];
+
+  homebrew = {
+    casks = [
+      "firefox"
+      "meetingbar"
+      "redis-insight"
+    ];
+  };
 }

--- a/nix/nix-darwin/hosts/work.nix
+++ b/nix/nix-darwin/hosts/work.nix
@@ -7,7 +7,6 @@
 
   # 仕事用 Mac だけで使うパッケージ。両方の Mac で使うものは home-manager/home.nix へ。
   home-manager.users.${username}.home.packages = with pkgs; [
-    gemini-cli
     # aws ssm start-session が PATH から呼ぶ session-manager-plugin 本体
     # (Homebrew の cask session-manager-plugin と同じもの)。
     ssm-session-manager-plugin


### PR DESCRIPTION
## 概要

仕事用 Mac (macOS アカウント名 `yoshiyama`) に nix 管理を適用するにあたって必要だった修正。実機で `make setup` → `make rebuild PROFILE=work` まで通し、Homebrew から nixpkgs への移行も完了した状態のもの。

## 変更点

### nix のインストールを make に組み込む (cb17893)

- `make install-nix` を追加。公式インストーラ (`artifacts.nixos.org/nix-installer`) を実行し、導入済みなら何もしない。`setup` は `install-nix → link → rebuild` に変更
- インストール直後は呼び出し元シェルに PATH が通らないため、`rebuild` / `dry-run` の先頭で `nix-daemon.sh` を読む (make のレシピは 1 行ごとに別シェルなので毎回必要)
- 初回は `darwin-rebuild` がまだ存在しないので、`rebuild` は flake.lock 固定の nix-darwin を build してその中の `darwin-rebuild` で activate するフォールバックを追加。**これが無いと新規マシンの初回 `make setup` が必ず失敗する**
- 初回 activate 前は flakes が有効でないため、nix 呼び出しに `--extra-experimental-features` を付与
- `.zshenv.sample` の `path` に nix の 3 パスを brew より前に追加。`setopt no_global_rcs` で `/etc/zshrc` を読まないため自前で通す必要がある

### work プロファイルの実機対応 (a597afa, a25dba1)

- work の `username` を実際の macOS アカウント名 `yoshiyama` に修正 (TODO コメントの解消)
- `hosts/work.nix` に仕事用 Mac 固有の差分を宣言
  - `ssm-session-manager-plugin` を nixpkgs へ移行 (cask から)
  - `firefox` / `meetingbar` / `redis-insight` は cask を継続

### PROFILE のデフォルト値を廃止 (d8a0b0a)

取り違えると別マシン向けの設定を activate してしまうため、`setup` / `rebuild` / `dry-run` で明示必須にした。

```
$ make dry-run
PROFILE を指定してください (指定可能: personal work)
  例: make rebuild PROFILE=work

$ make rebuild PROFILE=Work
不明な PROFILE: Work (指定可能: personal work)
```

指定可能な値は `hosts/*.nix` のファイル名から自動で拾うので、プロファイル追加時に Makefile を触る必要はない。チェックは nix を呼ぶ前に走る。

## 動作確認

- `make dry-run PROFILE=work` / `make rebuild PROFILE=work` 成功
- `make doctor` … 前提コマンド 3 つ [OK]、symlink 15 件すべて反映済み
- `gh` `rg` `lazygit` `codex` `alacritty` `nvim` `mise` `session-manager-plugin` がすべて `/etc/profiles/per-user/yoshiyama/bin/` に解決
- git identity … 通常は社用メール、`~/ghq/github.com/yopiyama/` 配下では noreply (includeIf 動作)
- Homebrew に残るのは宣言済みの `crit` / `im-select` と cask 9 個のみ

## 移行時のメモ (このリポジトリの変更ではない作業)

- brew の mise を消すと `~/.local/share/mise/shims/*` (91 個) が `/opt/homebrew/bin/mise` を指したまま全滅する。`mise reshim` で `/etc/profiles/per-user/<user>/bin/mise` に張り直せば、以降の rebuild でも壊れない
- `~/.config/git/config.local` の credential helper が `/opt/homebrew/bin/gh` をフルパス指定していたので `gh` に変更が必要だった

🤖 Generated with [Claude Code](https://claude.com/claude-code)