### PR TITLE
fix: nix 移行後に見つかったシェルまわりの不具合を直す

### DIFF
--- a/.tmux/launch_project.sh
+++ b/.tmux/launch_project.sh
@@ -18,12 +18,16 @@ die() { tmux display-message "launch_project: $*" 2>/dev/null || echo "launch_pr
 # 起動時モードのフォールバック: ピッカーを出せない/選ばなかったときは素のセッションへ
 startup_fallback() { exec tmux new-session -A -s "$STARTUP_SESSION"; }
 
+# 起動時モードでは JSON の妥当性まで見る。壊れていると後段の jq が set -e で落ち、
+# zshrc から exec された場合はシェルごと終了して端末が一切開けなくなるため。
 if [ -n "$STARTUP_SESSION" ]; then
-  { [ -f "$CONFIG" ] && command -v jq >/dev/null && command -v fzf >/dev/null; } || startup_fallback
+  { [ -f "$CONFIG" ] && command -v jq >/dev/null && command -v fzf >/dev/null \
+    && jq empty "$CONFIG" 2>/dev/null; } || startup_fallback
 else
   [ -f "$CONFIG" ] || die "$CONFIG が見つかりません (projects.json.sample をコピーしてください)"
   command -v jq  >/dev/null || die "jq が必要です"
   command -v fzf >/dev/null || die "fzf が必要です"
+  jq empty "$CONFIG" 2>/dev/null || die "$CONFIG が壊れています (JSON として読めません)"
 fi
 
 # name<TAB>path の一覧。起動時モードでは先頭に "+ new" (素のセッション) を加える。

--- a/.zshrc
+++ b/.zshrc
@@ -310,9 +310,8 @@ fi
 
 case ${OSTYPE} in
     darwin*)
-      alias xargs='gxargs'
-      alias sed='gsed'
-      alias awk='gawk'
+      # sed/awk/xargs は nixpkgs (gnused/gawk/findutils) が無印の名前で GNU 版を
+      # 入れるのでエイリアス不要。Homebrew 時代の g 付き名は存在しない。
       alias cpjson='pbpaste | jq | pbcopy'
       ;;
 esac


### PR DESCRIPTION
## 概要

Alacritty が起動しなくなった件の調査で見つかった 2 件の修正。

## Alacritty 即死の顛末 (このリポジトリの変更ではない)

直接の原因は `~/.tmux/projects.json` の行末が `,` ではなく `.` になっていた typo で、nix 移行とは無関係だった。ただし壊れ方が派手だったので経緯を残しておく。

1. `.zshrc` は Alacritty/iTerm で tmux セッションが無いとき `exec ~/.tmux/launch_project.sh --startup ...` する
2. `launch_project.sh` の `jq` が parse error で失敗する
3. スクリプトが `set -euo pipefail` なので即 exit。`exec` 済みなのでシェルごと終了し、Alacritty がウィンドウを閉じる

`alacritty -e /bin/sleep 20` は生き残るのに素の起動だけ即死する、という切り分けで特定した。iTerm も同じ経路なので道連れになっていた。

## 変更点

### `fix(tmux)`: projects.json が壊れていても端末が開けるようにする

`--startup` のフォールバックは「設定ファイルが無い / jq が無い / fzf が無い」しか見ておらず、JSON が壊れているケースを拾えていなかった。typo 1 文字で端末が一切開けなくなるのは事故なので、`jq empty` によるガードを追加する。

- 起動時モード … 壊れていれば素のセッションへフォールバック
- 通常モード (`prefix + C-p`) … 原因の分かるメッセージを出して終了

```
$ TMUX_PROJECTS_JSON=broken.json ./.tmux/launch_project.sh --startup test
open terminal failed: not a terminal   # フォールバックの exec tmux まで到達 (非 tty 環境のため失敗)

$ TMUX_PROJECTS_JSON=broken.json ./.tmux/launch_project.sh
launch_project: broken.json が壊れています (JSON として読めません)
```

### `fix(zsh)`: Homebrew 前提の GNU コマンドエイリアスを削除する

nixpkgs は g 付きではなく無印の名前で GNU 版を入れるため、移行後に壊れていた。

| エイリアス | 移行後の状態 |
| --- | --- |
| `alias sed='gsed'` | ❌ `command not found: gsed` |
| `alias xargs='gxargs'` | ❌ `gxargs` が無い |
| `alias awk='gawk'` | ⭕️ gawk は `gawk` も置くので動いていた |

nix 環境では `sed` / `awk` / `xargs` がそのまま GNU 版なのでエイリアス自体が不要。`cpjson` は残した。

```
$ sed --version | head -1
sed (GNU sed) 4.10
```

## 動作確認

- `bash -n` / `shellcheck` / `zsh -n` すべてパス
- typo 修正後、Alacritty は CLI 起動・`open` 経由の GUI 起動ともに正常
- 壊れた JSON でのフォールバックと通常モードのエラーメッセージを実際に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)